### PR TITLE
Feat: Entity 생성, Fix: mappedBy 오류 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,14 +25,14 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+//	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+//	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/wonpick/travel/server/controller/HomeController.java
+++ b/src/main/java/wonpick/travel/server/controller/HomeController.java
@@ -1,0 +1,17 @@
+package wonpick.travel.server.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+public class HomeController {
+
+    @GetMapping("/test")
+    public String hello() {
+        return "테스트입니다.";
+    }
+}
+
+

--- a/src/main/java/wonpick/travel/server/entity/BaseEntity.java
+++ b/src/main/java/wonpick/travel/server/entity/BaseEntity.java
@@ -1,0 +1,34 @@
+package wonpick.travel.server.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import lombok.Getter;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.sql.Timestamp;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(value = {AuditingEntityListener.class})
+public class BaseEntity {
+
+    private Timestamp createdAt;
+    private Timestamp updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        ZonedDateTime kst = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        this.createdAt = Timestamp.valueOf(kst.toLocalDateTime());
+        this.updatedAt = Timestamp.valueOf(kst.toLocalDateTime());
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        ZonedDateTime kst = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        this.updatedAt = Timestamp.valueOf(kst.toLocalDateTime());
+    }
+}

--- a/src/main/java/wonpick/travel/server/entity/Card.java
+++ b/src/main/java/wonpick/travel/server/entity/Card.java
@@ -43,9 +43,9 @@ public class Card extends BaseEntity {
     @Column(nullable = false)
     private CardType type;
 
-    @OneToMany(mappedBy = "cardBenefit", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "card", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CardBenefit> cardBenefits;
 
-    @OneToMany(mappedBy = "cardCategory", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "card", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CardCategory> cardCategories;
 }

--- a/src/main/java/wonpick/travel/server/entity/Card.java
+++ b/src/main/java/wonpick/travel/server/entity/Card.java
@@ -1,0 +1,51 @@
+package wonpick.travel.server.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wonpick.travel.server.entity.enums.CardType;
+
+import java.util.List;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Card extends BaseEntity {
+
+    @Id
+    @Column(name = "card_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(name = "annual_fee", nullable = false)
+    private Integer annualFee;
+
+    @Column(nullable = false)
+    private String image;
+
+    @Column(name = "detail_link", nullable = false)
+    private String detailLink;
+
+    @Column(name = "apply_link", nullable = false)
+    private String applyLink;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CardType type;
+
+    @OneToMany(mappedBy = "cardBenefit", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CardBenefit> cardBenefits;
+
+    @OneToMany(mappedBy = "cardCategory", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CardCategory> cardCategories;
+}

--- a/src/main/java/wonpick/travel/server/entity/CardBenefit.java
+++ b/src/main/java/wonpick/travel/server/entity/CardBenefit.java
@@ -1,0 +1,35 @@
+package wonpick.travel.server.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CardBenefit extends BaseEntity {
+
+    @Id
+    @Column(name = "cb_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "card_id", nullable = false)
+    private Card card;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String detail;
+
+    @Column(nullable = false)
+    private String image;
+
+
+}

--- a/src/main/java/wonpick/travel/server/entity/CardCategory.java
+++ b/src/main/java/wonpick/travel/server/entity/CardCategory.java
@@ -1,0 +1,30 @@
+package wonpick.travel.server.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wonpick.travel.server.entity.enums.CardCategoryType;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CardCategory extends BaseEntity{
+    @Id
+    @Column(name = "cc_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "card_id", nullable = false)
+    private Card card;
+
+    @Column(name="name", nullable = false)
+    private CardCategoryType categoryType;
+
+    @Column(nullable = false)
+    private String image;
+}

--- a/src/main/java/wonpick/travel/server/entity/CardCategory.java
+++ b/src/main/java/wonpick/travel/server/entity/CardCategory.java
@@ -22,6 +22,7 @@ public class CardCategory extends BaseEntity{
     @JoinColumn(name = "card_id", nullable = false)
     private Card card;
 
+    @Enumerated(EnumType.STRING)
     @Column(name="name", nullable = false)
     private CardCategoryType categoryType;
 

--- a/src/main/java/wonpick/travel/server/entity/Event.java
+++ b/src/main/java/wonpick/travel/server/entity/Event.java
@@ -1,0 +1,37 @@
+package wonpick.travel.server.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Event extends BaseEntity {
+    @Id
+    @Column(name = "event_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String image;
+
+    @Column(name = "p_image", nullable = false)
+    private String pImage;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDateTime startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDateTime endDate;
+
+    @Column(nullable = false)
+    private String state;
+}

--- a/src/main/java/wonpick/travel/server/entity/Flight.java
+++ b/src/main/java/wonpick/travel/server/entity/Flight.java
@@ -1,0 +1,70 @@
+package wonpick.travel.server.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Flight extends BaseEntity {
+
+    @Id
+    @Column(name = "flight_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id ;
+
+    // SpecialPricePick 엔티티와의 다대일 관계 설정
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sp_id", nullable = false)
+    private SpecialPricePick specialPricePick;
+
+    @Column(name = "airline", nullable = false, length = 20)
+    private String airline;
+
+    @Column(name = "flight_number", nullable = false, length = 20)
+    private String flightNumber;
+
+    @Column(name = "departure_place", nullable = false, length = 50)
+    private String departurePlace;
+
+    @Column(name = "arrival_place", nullable = false, length = 50)
+    private String arrivalPlace;
+
+    @Column(name = "departure_time", nullable = false)
+    private LocalDateTime departureTime;
+
+    @Column(name = "arrival_time", nullable = false)
+    private LocalDateTime arrivalTime;
+
+    @Column(name = "max_seat", nullable = false)
+    private int maxSeat;
+
+    @Column(name = "origin_price", nullable = false)
+    private int originPrice;
+
+    @Column(name = "special_price", nullable = false)
+    private int specialPrice;
+
+    @Column(name = "departure_airport_code", nullable = false, length = 20)
+    private String departureAirportCode;
+
+    @Column(name = "arrival_airport_code", nullable = false, length = 20)
+    private String arrivalAirportCode;
+
+    @Column(name = "baggage", nullable = false, length = 20)
+    private String baggage;
+
+    // ReservationFlight와 일대다 관계
+    @OneToMany(mappedBy = "flight", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReservationFlight> reservationFlights;
+
+}

--- a/src/main/java/wonpick/travel/server/entity/Passenger.java
+++ b/src/main/java/wonpick/travel/server/entity/Passenger.java
@@ -1,0 +1,43 @@
+package wonpick.travel.server.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wonpick.travel.server.entity.enums.Gender;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Passenger extends BaseEntity {
+
+    @Id
+    @Column(name = "passenger_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reservation_id", nullable = false)
+    private Reservation reservation;
+
+    @Column(name = "phone_number", nullable = false)
+    private String phoneNumber;
+
+    @Column(name = "first_name", nullable = false)
+    private String firstName;
+
+    @Column(name = "last_name", nullable = false)
+    private String lastName;
+
+    @Column(name = "birth", nullable = false)
+    private String birth;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender", nullable = false)
+    private Gender gender;
+
+
+}

--- a/src/main/java/wonpick/travel/server/entity/Reservation.java
+++ b/src/main/java/wonpick/travel/server/entity/Reservation.java
@@ -1,0 +1,43 @@
+package wonpick.travel.server.entity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Reservation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reservation_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "order_id", nullable = false, length = 6)
+    private String orderId;
+
+    @Column(name = "is_round_trip", nullable = false)
+    private Boolean isRoundTrip;
+
+    @Column(name = "buy_date", nullable = false)
+    private LocalDateTime buyDate;
+
+    @Column(name = "total_amount", nullable = false)
+    private int totalAmount;
+
+    // ReservationFlight와 일대다 관계
+    @OneToMany(mappedBy = "reservation", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReservationFlight> reservationFlights;
+}
+
+

--- a/src/main/java/wonpick/travel/server/entity/ReservationFlight.java
+++ b/src/main/java/wonpick/travel/server/entity/ReservationFlight.java
@@ -1,0 +1,26 @@
+package wonpick.travel.server.entity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+
+@Entity
+@Getter
+@Setter
+public class ReservationFlight {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "rf_id", nullable = false)
+    private Long id;
+
+    // ManyToOne 관계로 Reservation 연결
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reservation_id", nullable = false)
+    private Reservation reservation;
+
+    // ManyToOne 관계로 Flight 연결
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "flight_id", nullable = false)
+    private Flight flight;
+}

--- a/src/main/java/wonpick/travel/server/entity/SpecialPricePick.java
+++ b/src/main/java/wonpick/travel/server/entity/SpecialPricePick.java
@@ -1,0 +1,50 @@
+package wonpick.travel.server.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigInteger;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SpecialPricePick extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "sp_id", nullable = false)
+    private Long id;
+
+    @Column(name = "destination", nullable = false, length = 20)
+    private String destination;
+
+    @Column(name = "departure_date", nullable = false, length = 20)
+    private String departureDate;
+
+    @Column(name = "title", nullable = false, length = 20)
+    private String title;
+
+    @Column(name = "description", nullable = false, length = 100)
+    private String description;
+
+    @Column(name = "open_time", nullable = false)
+    private LocalDateTime openTime;
+
+    @Column(name = "close_time", nullable = false)
+    private LocalDateTime closeTime;
+
+    @Column(name = "state", nullable = false)
+    private String state;
+
+    @Column(name = "category", nullable = false, length = 20)
+    private String category;
+
+    // Flight 엔티티와의 일대다 관계 설정
+    @OneToMany(mappedBy = "specialPricePick", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Flight> flights;
+}

--- a/src/main/java/wonpick/travel/server/entity/User.java
+++ b/src/main/java/wonpick/travel/server/entity/User.java
@@ -1,0 +1,43 @@
+package wonpick.travel.server.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class User extends BaseEntity {
+
+    @Id
+    @Column(name = "user_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(name = "phone_number", nullable = false)
+    private String phoneNumber;
+
+    @Column
+    private Boolean notification;
+
+    @OneToMany(mappedBy = "userPassenger", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserPassenger> userPassengers;
+
+    @OneToMany(mappedBy = "reservation", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Reservation> reservations;
+
+}
+
+

--- a/src/main/java/wonpick/travel/server/entity/User.java
+++ b/src/main/java/wonpick/travel/server/entity/User.java
@@ -32,10 +32,10 @@ public class User extends BaseEntity {
     @Column
     private Boolean notification;
 
-    @OneToMany(mappedBy = "userPassenger", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserPassenger> userPassengers;
 
-    @OneToMany(mappedBy = "reservation", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Reservation> reservations;
 
 }

--- a/src/main/java/wonpick/travel/server/entity/UserPassenger.java
+++ b/src/main/java/wonpick/travel/server/entity/UserPassenger.java
@@ -1,0 +1,43 @@
+package wonpick.travel.server.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wonpick.travel.server.entity.enums.Gender;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserPassenger extends BaseEntity {
+
+    @Id
+    @Column(name = "up_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "first_name", nullable = false)
+    private String firstName;
+
+    @Column(name = "last_name", nullable = false)
+    private String lastName;
+
+    @Column(nullable = false)
+    private String birth;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Gender gender;
+
+    @Column(name = "phone_number", nullable = false)
+    private String phoneNumber;
+
+
+}

--- a/src/main/java/wonpick/travel/server/entity/enums/CardCategoryType.java
+++ b/src/main/java/wonpick/travel/server/entity/enums/CardCategoryType.java
@@ -1,0 +1,31 @@
+package wonpick.travel.server.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CardCategoryType {
+
+    ALL_MERCHANTS("모든 가맹점"),
+    PUBLIC_TRANSPORT("대중교통"),
+    FUEL_CAR("주유/자동차"),
+    TELECOMMUNICATION("통신"),
+    SHOPPING_MART("쇼핑/마트"),
+    DINING("외식"),
+    COFFEE("커피"),
+    ONLINE("온라인"),
+    OTT_DELIVERY("OTT/배달"),
+    MAINTENANCE_FEE("관리비"),
+    TRAVEL("여행/해외"),
+    LODGING_VALET_PARKING("숙박/발렛파킹"),
+    AIRPORT_LOUNGE("공항 라운지"),
+    PREMIUM("프리미엄"),
+    PETS("애완동물"),
+    HOSPITAL("병원"),
+    EDUCATION_PARENTING("교육/육아"),
+    MOVIES_CULTURE("영화/문화"),
+    LEISURE_SPORTS("레저/스포츠");
+
+    private final String description;
+}

--- a/src/main/java/wonpick/travel/server/entity/enums/CardType.java
+++ b/src/main/java/wonpick/travel/server/entity/enums/CardType.java
@@ -1,0 +1,14 @@
+package wonpick.travel.server.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CardType {
+    CREDIT("신용카드"),
+    CHECK("체크카드");
+
+    private final String type;
+
+}

--- a/src/main/java/wonpick/travel/server/entity/enums/Gender.java
+++ b/src/main/java/wonpick/travel/server/entity/enums/Gender.java
@@ -1,0 +1,11 @@
+package wonpick.travel.server.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Gender {
+    MALE("남성"), FEMALE("여성");
+    private final String description;
+}

--- a/src/main/java/wonpick/travel/server/repository/UserRepository.java
+++ b/src/main/java/wonpick/travel/server/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package wonpick.travel.server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import wonpick.travel.server.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=server

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/travelwonpick
+    username: root
+    password: root
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+
+server:
+  servlet:
+    session:
+      timeout: 1h


### PR DESCRIPTION
## #️⃣연관된 이슈

> #4, #5

## 📝작업 내용

1. 연관 관계 고려하여 Entity를 생성
2. mappedBy로 인해 발생한 BeanCreationException 해결
3. Spring Data JPA 사용하여 자동으로 DB 생성

### 고려 사항
- 엔티티 내부에서 사용하는 시간 정보에 대해서는 `LocalDateTime` 적용, CreatedAt 및 UpdatedAt에는 Timestamp 적용
- Enum 타입 고려 (신용/체크카드 여부, 성별, 카드 필터링 조건)
- 일대다 관계에서 mappedBy는 반대쪽 엔티티에서 현재 엔티티를 참조하는 필드 이름과 일치해야 합니다.


**기존 코드(Card.java)**

```java
@OneToMany(mappedBy = "cardBenefit", cascade = CascadeType.ALL, orphanRemoval = true)
private List<CardBenefit> cardBenefits;
```

**개선 코드**
```java
@OneToMany(mappedBy = "card", cascade = CascadeType.ALL, orphanRemoval = true)
private List<CardBenefit> cardBenefits;
```

